### PR TITLE
77109

### DIFF
--- a/app/Espo/Services/Stream.php
+++ b/app/Espo/Services/Stream.php
@@ -1239,12 +1239,16 @@ class Stream extends \Espo\Core\Services\Base
             if ($updated) {
                 $updatedFieldList[] = $field;
                 foreach ($item['actualList'] as $attribute) {
-                    $was[$attribute] = $entity->getFetched($attribute);
-                    $became[$attribute] = $entity->get($attribute);
+                    if ($entity->isAttributeChanged($attribute)) {
+                        $was[$attribute] = $entity->getFetched($attribute);
+                        $became[$attribute] = $entity->get($attribute);
+                    }
                 }
                 foreach ($item['notActualList'] as $attribute) {
-                    $was[$attribute] = $entity->getFetched($attribute);
-                    $became[$attribute] = $entity->get($attribute);
+                    if ($entity->isAttributeChanged($attribute)) {
+                        $was[$attribute] = $entity->getFetched($attribute);
+                        $became[$attribute] = $entity->get($attribute);
+                    }
                 }
 
                 if ($item['fieldType'] === 'linkParent') {

--- a/client/modules/treo-core/src/views/stream/notes/update.js
+++ b/client/modules/treo-core/src/views/stream/notes/update.js
@@ -59,6 +59,7 @@ Espo.define('treo-core:views/stream/notes/update', 'views/stream/notes/update', 
                 this.fieldsArr = [];
 
                 fields = this.addMultilangFields(model, fields);
+                fields = fields.filter(field => modelWas.has(field) && modelBecame.has(field));
 
                 fields.forEach(function (field) {
                     let type = this.model.get('attributeType') || model.getFieldType(field) || 'base';


### PR DESCRIPTION
Removed the basic option from the multilingual name in stream update note.
After entity saving in Note entity will save only fields or their locales where have been changes.